### PR TITLE
feat(devkit): scaffold analysis, cli, types, and error modules

### DIFF
--- a/packages/devkit/Cargo.toml
+++ b/packages/devkit/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 description = "Developer toolkit for testing and simulating the Stellar fee tracker"
 
 [dependencies]
+thiserror = "1"

--- a/packages/devkit/src/analysis/mod.rs
+++ b/packages/devkit/src/analysis/mod.rs
@@ -1,0 +1,3 @@
+pub mod percentile;
+pub mod rolling_window;
+pub mod spike_classifier;

--- a/packages/devkit/src/analysis/percentile.rs
+++ b/packages/devkit/src/analysis/percentile.rs
@@ -1,0 +1,2 @@
+/// Computes percentile statistics over fee samples.
+pub struct Percentile;

--- a/packages/devkit/src/analysis/rolling_window.rs
+++ b/packages/devkit/src/analysis/rolling_window.rs
@@ -1,0 +1,2 @@
+/// Maintains a rolling window of fee observations.
+pub struct RollingWindow;

--- a/packages/devkit/src/analysis/spike_classifier.rs
+++ b/packages/devkit/src/analysis/spike_classifier.rs
@@ -1,0 +1,2 @@
+/// Classifies fee spikes in a time series.
+pub struct SpikeClassifier;

--- a/packages/devkit/src/cli/benchmark.rs
+++ b/packages/devkit/src/cli/benchmark.rs
@@ -1,0 +1,2 @@
+/// Runs benchmarks against the fee tracker pipeline.
+pub struct Benchmark;

--- a/packages/devkit/src/cli/export.rs
+++ b/packages/devkit/src/cli/export.rs
@@ -1,0 +1,2 @@
+/// Exports devkit results to external formats.
+pub struct Export;

--- a/packages/devkit/src/cli/mod.rs
+++ b/packages/devkit/src/cli/mod.rs
@@ -1,0 +1,3 @@
+pub mod benchmark;
+pub mod export;
+pub mod replay;

--- a/packages/devkit/src/cli/replay.rs
+++ b/packages/devkit/src/cli/replay.rs
@@ -1,0 +1,2 @@
+/// Replays recorded fee scenarios against the devkit harness.
+pub struct Replay;

--- a/packages/devkit/src/error.rs
+++ b/packages/devkit/src/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+/// Unified error type for the devkit.
+#[derive(Debug, Error)]
+pub enum DevkitError {
+    #[error("simulation error: {0}")]
+    Simulation(String),
+
+    #[error("harness error: {0}")]
+    Harness(String),
+
+    #[error("analysis error: {0}")]
+    Analysis(String),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/packages/devkit/src/lib.rs
+++ b/packages/devkit/src/lib.rs
@@ -1,2 +1,6 @@
+pub mod analysis;
+pub mod cli;
+pub mod error;
 pub mod harness;
 pub mod simulation;
+pub mod types;

--- a/packages/devkit/src/types.rs
+++ b/packages/devkit/src/types.rs
@@ -1,0 +1,8 @@
+/// A single fee observation from the Stellar network.
+pub struct FeeRecord;
+
+/// A named test scenario for the devkit harness.
+pub struct Scenario;
+
+/// The result of a simulation run.
+pub struct SimResult;


### PR DESCRIPTION
## Summary

Closes #95 
Closes #96  
Closes  #97  
Closes #98  

## Changes

- **#95** — Add `analysis` module with `percentile`, `spike_classifier`, and `rolling_window` stubs
- **#96** — Add `cli` module with `replay`, `export`, and `benchmark` stubs
- **#97** — Add shared `types` module with `FeeRecord`, `Scenario`, and `SimResult` stubs
- **#98** — Add `DevkitError` enum using `thiserror`; add `thiserror` dep to `Cargo.toml`