### PR TITLE
feat(devkit/harness): load scenario from file at runtime

### DIFF
--- a/packages/devkit/src/harness/horizon_mock.rs
+++ b/packages/devkit/src/harness/horizon_mock.rs
@@ -1,2 +1,16 @@
 /// Mock implementation of the Horizon API server for use in tests.
-pub struct HorizonMock;
+pub struct HorizonMock {
+    /// Path to the scenario JSON file to serve.
+    pub scenario_path: std::path::PathBuf,
+}
+
+impl HorizonMock {
+    pub fn new(scenario_path: impl Into<std::path::PathBuf>) -> Self {
+        Self { scenario_path: scenario_path.into() }
+    }
+
+    /// Loads and returns the scenario JSON to be served at `GET /fee_stats`.
+    pub fn fee_stats_payload(&self) -> std::io::Result<String> {
+        crate::harness::scenarios::load_from_file(&self.scenario_path)
+    }
+}

--- a/packages/devkit/src/harness/scenarios/mod.rs
+++ b/packages/devkit/src/harness/scenarios/mod.rs
@@ -1,1 +1,8 @@
 //! Pre-built test scenarios for the Stellar fee tracker harness.
+
+use std::path::Path;
+
+/// Loads a scenario JSON file from the given path and returns its contents.
+pub fn load_from_file(path: &Path) -> std::io::Result<String> {
+    std::fs::read_to_string(path)
+}


### PR DESCRIPTION
## Summary

Closes #106

## Changes

- `horizon_mock.rs`: `HorizonMock` now accepts a `scenario_path` and exposes `fee_stats_payload()` which reads and returns the JSON to serve at `GET /fee_stats`
- `scenarios/mod.rs`: adds `load_from_file(path)` helper that reads a scenario JSON from disk