### PR TITLE
feat(devkit): percentile functions and simulation docs

### DIFF
--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -25,6 +25,36 @@ Developer toolkit for the Stellar Fee Tracker. Provides utilities for testing, m
 | `types` | Shared types: `FeeRecord`, `Scenario`, `SimResult` |
 | `error` | `DevkitError` unified error enum |
 
+## Simulation
+
+The `simulation` module provides fee modelling and network-load generation without any live-network dependencies.
+
+### `FeeModelConfig` fields
+
+| Field | Type | Description |
+|---|---|---|
+| `base_fee` | `u64` | Minimum fee (stroops) used as the simulation floor |
+| `surge_multiplier` | `f64` | Fee multiplier applied when the network is congested |
+| `congestion_threshold` | `f64` | Load ratio (0.0–1.0) above which surge pricing activates |
+
+### Example usage
+
+```rust
+use stellar_devkit::simulation::{FeeModel, NetworkLoad};
+
+let load = NetworkLoad::constant(0.85);          // 85 % utilisation
+let result = FeeModel::run(&load, base_fee: 100, surge_multiplier: 2.0, congestion_threshold: 0.8);
+println!("recommended fee: {} stroops", result.recommended_fee);
+```
+
+### Output format (`SimResult`)
+
+| Field | Type | Description |
+|---|---|---|
+| `recommended_fee` | `u64` | Suggested fee for the simulated conditions |
+| `congested` | `bool` | Whether surge pricing was triggered |
+| `load_ratio` | `f64` | Network utilisation at simulation time |
+
 ## Running
 
 ```bash

--- a/packages/devkit/src/analysis/percentile.rs
+++ b/packages/devkit/src/analysis/percentile.rs
@@ -1,2 +1,61 @@
 /// Computes percentile statistics over fee samples.
 pub struct Percentile;
+
+impl Percentile {
+    /// Returns the nearest-rank percentile of a sorted slice.
+    /// `p` must be in 1..=100. Returns 0 for empty slices.
+    pub fn nearest_rank(sorted: &[u64], p: usize) -> u64 {
+        if sorted.is_empty() {
+            return 0;
+        }
+        let idx = ((p as f64 / 100.0) * sorted.len() as f64).ceil() as usize;
+        sorted[idx.saturating_sub(1).min(sorted.len() - 1)]
+    }
+
+    /// Returns the linear-interpolation percentile of a sorted slice.
+    /// `p` must be in 0..=100. Returns 0 for empty slices.
+    pub fn linear_interpolation(sorted: &[u64], p: usize) -> u64 {
+        if sorted.is_empty() {
+            return 0;
+        }
+        if sorted.len() == 1 {
+            return sorted[0];
+        }
+        let rank = (p as f64 / 100.0) * (sorted.len() - 1) as f64;
+        let lo = rank.floor() as usize;
+        let hi = rank.ceil() as usize;
+        let frac = rank - lo as f64;
+        (sorted[lo] as f64 + frac * (sorted[hi] as f64 - sorted[lo] as f64)).round() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nearest_rank_basic() {
+        let data = [10, 20, 30, 40, 50];
+        assert_eq!(Percentile::nearest_rank(&data, 50), 30);
+        assert_eq!(Percentile::nearest_rank(&data, 100), 50);
+        assert_eq!(Percentile::nearest_rank(&data, 1), 10);
+    }
+
+    #[test]
+    fn nearest_rank_empty() {
+        assert_eq!(Percentile::nearest_rank(&[], 50), 0);
+    }
+
+    #[test]
+    fn linear_interpolation_basic() {
+        let data = [10, 20, 30, 40, 50];
+        assert_eq!(Percentile::linear_interpolation(&data, 0), 10);
+        assert_eq!(Percentile::linear_interpolation(&data, 100), 50);
+        assert_eq!(Percentile::linear_interpolation(&data, 50), 30);
+    }
+
+    #[test]
+    fn linear_interpolation_empty() {
+        assert_eq!(Percentile::linear_interpolation(&[], 50), 0);
+    }
+}


### PR DESCRIPTION
Closes #135,

Closes #136, 

Closes #137, 

Closes #138 

- `Percentile::nearest_rank` — nearest-rank method with unit tests
- `Percentile::linear_interpolation` — linear interpolation method with unit tests
- Simulation module documented in `packages/devkit/README.md`