### PR TITLE
feat(devkit): spike classifier + percentile tests (#139 #140 #141 #142)

### DIFF
--- a/packages/devkit/src/analysis/spike_classifier.rs
+++ b/packages/devkit/src/analysis/spike_classifier.rs
@@ -1,2 +1,78 @@
+/// Severity level of a detected fee spike.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpikeSeverity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+/// A single detected fee spike event.
+#[derive(Debug, Clone)]
+pub struct SpikeEvent {
+    pub timestamp: u64,
+    pub fee_amount: u64,
+    pub baseline: u64,
+    pub multiplier: f64,
+    pub severity: SpikeSeverity,
+}
+
 /// Classifies fee spikes in a time series.
 pub struct SpikeClassifier;
+
+impl SpikeClassifier {
+    /// Detects spikes where `fee > baseline * threshold`.
+    /// Returns a `Vec<SpikeEvent>` for every entry that exceeds the threshold.
+    pub fn detect(fees: &[(u64, u64)], baseline: u64, threshold: f64) -> Vec<SpikeEvent> {
+        fees.iter()
+            .filter_map(|&(timestamp, fee_amount)| {
+                let multiplier = fee_amount as f64 / baseline as f64;
+                if multiplier > threshold {
+                    let severity = if multiplier < 2.0 {
+                        SpikeSeverity::Low
+                    } else if multiplier < 5.0 {
+                        SpikeSeverity::Medium
+                    } else if multiplier < 10.0 {
+                        SpikeSeverity::High
+                    } else {
+                        SpikeSeverity::Critical
+                    };
+                    Some(SpikeEvent { timestamp, fee_amount, baseline, multiplier, severity })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_spikes_above_threshold() {
+        let fees = [(1, 100), (2, 250), (3, 90), (4, 600)];
+        let spikes = SpikeClassifier::detect(&fees, 100, 1.5);
+        assert_eq!(spikes.len(), 2);
+        assert_eq!(spikes[0].timestamp, 2);
+        assert_eq!(spikes[1].timestamp, 4);
+    }
+
+    #[test]
+    fn no_spikes_below_threshold() {
+        let fees = [(1, 100), (2, 110), (3, 95)];
+        let spikes = SpikeClassifier::detect(&fees, 100, 1.5);
+        assert!(spikes.is_empty());
+    }
+
+    #[test]
+    fn severity_levels() {
+        let fees = [(1, 150), (2, 300), (3, 700), (4, 1100)];
+        let spikes = SpikeClassifier::detect(&fees, 100, 1.0);
+        assert_eq!(spikes[0].severity, SpikeSeverity::Low);
+        assert_eq!(spikes[1].severity, SpikeSeverity::Medium);
+        assert_eq!(spikes[2].severity, SpikeSeverity::High);
+        assert_eq!(spikes[3].severity, SpikeSeverity::Critical);
+    }
+}

--- a/packages/devkit/tests/percentile.rs
+++ b/packages/devkit/tests/percentile.rs
@@ -1,0 +1,84 @@
+use stellar_devkit::analysis::percentile::Percentile;
+
+// ── Issue #139: nearest-rank percentile tests ────────────────────────────────
+
+#[test]
+fn nearest_rank_p10_p50_p90_p95_p99() {
+    let data: Vec<u64> = (1..=100).collect();
+    assert_eq!(Percentile::nearest_rank(&data, 10), 10);
+    assert_eq!(Percentile::nearest_rank(&data, 50), 50);
+    assert_eq!(Percentile::nearest_rank(&data, 90), 90);
+    assert_eq!(Percentile::nearest_rank(&data, 95), 95);
+    assert_eq!(Percentile::nearest_rank(&data, 99), 99);
+}
+
+#[test]
+fn nearest_rank_single_element() {
+    assert_eq!(Percentile::nearest_rank(&[42], 50), 42);
+    assert_eq!(Percentile::nearest_rank(&[42], 1), 42);
+    assert_eq!(Percentile::nearest_rank(&[42], 100), 42);
+}
+
+#[test]
+fn nearest_rank_empty_returns_zero() {
+    assert_eq!(Percentile::nearest_rank(&[], 50), 0);
+}
+
+#[test]
+fn nearest_rank_small_dataset() {
+    let data = [10u64, 20, 30, 40, 50];
+    assert_eq!(Percentile::nearest_rank(&data, 1), 10);
+    assert_eq!(Percentile::nearest_rank(&data, 50), 30);
+    assert_eq!(Percentile::nearest_rank(&data, 100), 50);
+}
+
+// ── Issue #140: interpolation percentile tests ───────────────────────────────
+
+#[test]
+fn interpolation_p10_p50_p90_p95_p99() {
+    let data: Vec<u64> = (1..=100).collect();
+    assert_eq!(Percentile::linear_interpolation(&data, 10), 10);
+    assert_eq!(Percentile::linear_interpolation(&data, 50), 50);
+    assert_eq!(Percentile::linear_interpolation(&data, 90), 90);
+    assert_eq!(Percentile::linear_interpolation(&data, 95), 95);
+    assert_eq!(Percentile::linear_interpolation(&data, 99), 99);
+}
+
+#[test]
+fn interpolation_boundaries() {
+    let data = [10u64, 20, 30, 40, 50];
+    assert_eq!(Percentile::linear_interpolation(&data, 0), 10);
+    assert_eq!(Percentile::linear_interpolation(&data, 100), 50);
+}
+
+#[test]
+fn interpolation_midpoint_is_average() {
+    // p50 of [10, 20] should interpolate to 15
+    let data = [10u64, 20];
+    assert_eq!(Percentile::linear_interpolation(&data, 50), 15);
+}
+
+#[test]
+fn interpolation_single_element() {
+    assert_eq!(Percentile::linear_interpolation(&[7], 50), 7);
+}
+
+#[test]
+fn interpolation_empty_returns_zero() {
+    assert_eq!(Percentile::linear_interpolation(&[], 50), 0);
+}
+
+/// Nearest-rank and interpolation agree on exact-rank positions.
+#[test]
+fn nearest_rank_vs_interpolation_same_on_exact_ranks() {
+    let data: Vec<u64> = (1..=10).collect();
+    for p in [10usize, 20, 30, 40, 50, 60, 70, 80, 90, 100] {
+        let nr = Percentile::nearest_rank(&data, p);
+        let li = Percentile::linear_interpolation(&data, p);
+        // They may differ by at most 1 due to rounding; document the difference.
+        assert!(
+            nr.abs_diff(li) <= 1,
+            "p{p}: nearest_rank={nr}, linear_interpolation={li}, diff > 1"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Resolves four issues assigned to PortableDD in the `packages/devkit` analysis module.

## Changes

### `src/analysis/spike_classifier.rs`
- **`SpikeSeverity` enum** — Low / Medium / High / Critical (closes #141)
- **`SpikeEvent` struct** — timestamp, fee_amount, baseline, multiplier, severity (closes #141)
- **`SpikeClassifier::detect(fees, baseline, threshold)`** — filters entries where `fee > baseline * threshold`, computes multiplier, assigns severity, returns `Vec<SpikeEvent>` (closes #142)

### `tests/percentile.rs` (new file)
- **Nearest-rank tests** — p10, p50, p90, p95, p99 on a 1–100 dataset; single-element; empty; small dataset (closes #139)
- **Interpolation tests** — same percentile points; boundary (p0/p100); midpoint interpolation; single-element; empty (closes #140)
- **Cross-method comparison** — asserts nearest-rank and linear-interpolation agree within ±1 on exact-rank positions, documenting expected differences

## Closes
Closes #139
Closes #140
Closes #141
Closes #142