### PR TITLE
feat(devkit): spike severity/duration classification, SMA, and unit tests

### DIFF
--- a/packages/devkit/src/analysis/rolling_window.rs
+++ b/packages/devkit/src/analysis/rolling_window.rs
@@ -1,2 +1,42 @@
 /// Maintains a rolling window of fee observations.
-pub struct RollingWindow;
+pub struct RollingWindow {
+    window: usize,
+    buf: std::collections::VecDeque<f64>,
+}
+
+impl RollingWindow {
+    pub fn new(window: usize) -> Self {
+        assert!(window > 0, "window size must be > 0");
+        Self { window, buf: std::collections::VecDeque::with_capacity(window) }
+    }
+
+    /// Push a new fee value and return the current SMA if the window is full.
+    pub fn push(&mut self, fee: f64) -> Option<f64> {
+        if self.buf.len() == self.window {
+            self.buf.pop_front();
+        }
+        self.buf.push_back(fee);
+        if self.buf.len() == self.window {
+            Some(self.buf.iter().sum::<f64>() / self.window as f64)
+        } else {
+            None
+        }
+    }
+
+    /// Compute SMA over a complete slice with the configured window size.
+    /// Returns one value per position once the window is full.
+    pub fn sma(fees: &[f64], window: usize) -> Vec<f64> {
+        assert!(window > 0, "window size must be > 0");
+        if fees.len() < window {
+            return vec![];
+        }
+        let mut result = Vec::with_capacity(fees.len() - window + 1);
+        let mut sum: f64 = fees[..window].iter().sum();
+        result.push(sum / window as f64);
+        for i in window..fees.len() {
+            sum += fees[i] - fees[i - window];
+            result.push(sum / window as f64);
+        }
+        result
+    }
+}

--- a/packages/devkit/src/analysis/spike_classifier.rs
+++ b/packages/devkit/src/analysis/spike_classifier.rs
@@ -1,2 +1,75 @@
+/// Severity level of a fee spike relative to baseline.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpikeSeverity {
+    /// 2–5× baseline
+    Low,
+    /// 5–10× baseline
+    Medium,
+    /// 10–50× baseline
+    High,
+    /// >50× baseline
+    Critical,
+}
+
+/// A detected spike with its severity and duration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpikeEvent {
+    pub severity: SpikeSeverity,
+    /// Number of consecutive ledgers the spike persisted.
+    pub duration_ledgers: usize,
+}
+
 /// Classifies fee spikes in a time series.
 pub struct SpikeClassifier;
+
+impl SpikeClassifier {
+    /// Classify a single fee against a baseline.
+    /// Returns `None` if the fee is below the 2× spike threshold.
+    pub fn classify(fee: u64, baseline: u64) -> Option<SpikeSeverity> {
+        if baseline == 0 {
+            return None;
+        }
+        let ratio = fee as f64 / baseline as f64;
+        match ratio {
+            r if r > 50.0 => Some(SpikeSeverity::Critical),
+            r if r >= 10.0 => Some(SpikeSeverity::High),
+            r if r >= 5.0 => Some(SpikeSeverity::Medium),
+            r if r >= 2.0 => Some(SpikeSeverity::Low),
+            _ => None,
+        }
+    }
+
+    /// Detect all spike events in a fee sequence given a fixed baseline.
+    /// Consecutive ledgers above the 2× threshold are grouped into one event.
+    pub fn detect(fees: &[u64], baseline: u64) -> Vec<SpikeEvent> {
+        let mut events = Vec::new();
+        let mut i = 0;
+        while i < fees.len() {
+            if let Some(severity) = Self::classify(fees[i], baseline) {
+                let start = i;
+                // Advance while still a spike (any severity)
+                while i < fees.len() && Self::classify(fees[i], baseline).is_some() {
+                    i += 1;
+                }
+                // Severity of the event = max severity seen in the run
+                let severity = fees[start..i]
+                    .iter()
+                    .filter_map(|&f| Self::classify(f, baseline))
+                    .max_by_key(|s| match s {
+                        SpikeSeverity::Low => 1,
+                        SpikeSeverity::Medium => 2,
+                        SpikeSeverity::High => 3,
+                        SpikeSeverity::Critical => 4,
+                    })
+                    .unwrap_or(severity);
+                events.push(SpikeEvent {
+                    severity,
+                    duration_ledgers: i - start,
+                });
+            } else {
+                i += 1;
+            }
+        }
+        events
+    }
+}

--- a/packages/devkit/tests/spike_classifier.rs
+++ b/packages/devkit/tests/spike_classifier.rs
@@ -1,0 +1,88 @@
+use stellar_devkit::analysis::spike_classifier::{SpikeClassifier, SpikeSeverity};
+
+// ── classify ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn classify_below_threshold_returns_none() {
+    assert_eq!(SpikeClassifier::classify(199, 100), None);
+}
+
+#[test]
+fn classify_low_severity() {
+    assert_eq!(SpikeClassifier::classify(200, 100), Some(SpikeSeverity::Low));
+    assert_eq!(SpikeClassifier::classify(499, 100), Some(SpikeSeverity::Low));
+}
+
+#[test]
+fn classify_medium_severity() {
+    assert_eq!(SpikeClassifier::classify(500, 100), Some(SpikeSeverity::Medium));
+    assert_eq!(SpikeClassifier::classify(999, 100), Some(SpikeSeverity::Medium));
+}
+
+#[test]
+fn classify_high_severity() {
+    assert_eq!(SpikeClassifier::classify(1_000, 100), Some(SpikeSeverity::High));
+    assert_eq!(SpikeClassifier::classify(4_999, 100), Some(SpikeSeverity::High));
+}
+
+#[test]
+fn classify_critical_severity() {
+    assert_eq!(SpikeClassifier::classify(5_001, 100), Some(SpikeSeverity::Critical));
+}
+
+#[test]
+fn classify_zero_baseline_returns_none() {
+    assert_eq!(SpikeClassifier::classify(1_000, 0), None);
+}
+
+// ── detect ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn detect_no_spikes_in_flat_sequence() {
+    let fees = vec![100u64; 10];
+    assert!(SpikeClassifier::detect(&fees, 100).is_empty());
+}
+
+#[test]
+fn detect_single_spike_correct_count_and_severity() {
+    // one Low spike surrounded by baseline
+    let fees = vec![100, 100, 300, 100, 100];
+    let events = SpikeClassifier::detect(&fees, 100);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].severity, SpikeSeverity::Low);
+    assert_eq!(events[0].duration_ledgers, 1);
+}
+
+#[test]
+fn detect_consecutive_spike_duration() {
+    // three consecutive ledgers at 6× baseline → one Medium event of duration 3
+    let fees = vec![100, 600, 600, 600, 100];
+    let events = SpikeClassifier::detect(&fees, 100);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].severity, SpikeSeverity::Medium);
+    assert_eq!(events[0].duration_ledgers, 3);
+}
+
+#[test]
+fn detect_multiple_separate_spikes() {
+    let fees = vec![100, 300, 100, 1_500, 100];
+    let events = SpikeClassifier::detect(&fees, 100);
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].severity, SpikeSeverity::Low);
+    assert_eq!(events[1].severity, SpikeSeverity::High);
+}
+
+#[test]
+fn detect_escalating_spike_uses_max_severity() {
+    // run goes Low → Critical; event should be Critical
+    let fees = vec![100, 300, 6_000, 100];
+    let events = SpikeClassifier::detect(&fees, 100);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].severity, SpikeSeverity::Critical);
+    assert_eq!(events[0].duration_ledgers, 2);
+}
+
+#[test]
+fn detect_empty_slice_returns_empty() {
+    assert!(SpikeClassifier::detect(&[], 100).is_empty());
+}


### PR DESCRIPTION
## Summary

Implements all four issues assigned to @tolulopedd26.

### Changes

**`packages/devkit/src/analysis/spike_classifier.rs`**
- `SpikeSeverity` enum: `Low` (2–5×), `Medium` (5–10×), `High` (10–50×), `Critical` (>50×) baseline
- `SpikeClassifier::classify(fee, baseline)` — classifies a single fee reading
- `SpikeEvent` struct with `severity` and `duration_ledgers`
- `SpikeClassifier::detect(fees, baseline)` — groups consecutive spike ledgers into events, reports max severity and duration

**`packages/devkit/src/analysis/rolling_window.rs`**
- `RollingWindow::new(window)` + `push(fee)` — incremental SMA, returns `Some(sma)` once window is full
- `RollingWindow::sma(fees, window)` — batch SMA over a complete slice

**`packages/devkit/tests/spike_classifier.rs`**
- 11 unit tests covering all severity levels, consecutive-spike duration, multiple separate spikes, escalating severity, zero baseline, and empty input

### Testing

CI (`cargo test --all`) will validate all tests on push.

Closes #143
Closes #144
Closes #145
Closes #146