### PR TITLE
fix: implement fee distribution summary, IQR outliers, and analysis benchmarks

### DIFF
--- a/packages/devkit/Cargo.toml
+++ b/packages/devkit/Cargo.toml
@@ -19,3 +19,11 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "fee_model_bench"
 harness = false
+
+[[bench]]
+name = "percentile_bench"
+harness = false
+
+[[bench]]
+name = "rolling_window_bench"
+harness = false

--- a/packages/devkit/benches/percentile_bench.rs
+++ b/packages/devkit/benches/percentile_bench.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use stellar_devkit::analysis::percentile::Percentile;
+
+fn bench_percentile_algorithms(c: &mut Criterion) {
+    let mut data: Vec<u64> = (1u64..=1_000_000).collect();
+    data.sort_unstable();
+
+    let mut group = c.benchmark_group("percentile_1M");
+
+    group.bench_with_input(BenchmarkId::new("nearest_rank", "p50"), &data, |b, d| {
+        b.iter(|| Percentile::nearest_rank(d, 50))
+    });
+
+    group.bench_with_input(BenchmarkId::new("linear_interpolation", "p50"), &data, |b, d| {
+        b.iter(|| Percentile::linear_interpolation(d, 50))
+    });
+
+    group.bench_with_input(BenchmarkId::new("fee_distribution_summary", "all"), &data, |b, d| {
+        b.iter(|| Percentile::fee_distribution_summary(d))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_percentile_algorithms);
+criterion_main!(benches);

--- a/packages/devkit/benches/rolling_window_bench.rs
+++ b/packages/devkit/benches/rolling_window_bench.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use stellar_devkit::analysis::rolling_window::RollingWindow;
+
+fn bench_rolling_window_algorithms(c: &mut Criterion) {
+    let data: Vec<u64> = (1u64..=100_000).collect();
+    let window = 50;
+
+    let mut group = c.benchmark_group("rolling_window_100k");
+
+    group.bench_with_input(BenchmarkId::new("sma", window), &data, |b, d| {
+        b.iter(|| RollingWindow::sma(d, window))
+    });
+
+    group.bench_with_input(BenchmarkId::new("ema", "alpha=0.1"), &data, |b, d| {
+        b.iter(|| RollingWindow::ema(d, 0.1))
+    });
+
+    group.bench_with_input(BenchmarkId::new("wma", window), &data, |b, d| {
+        b.iter(|| RollingWindow::wma(d, window))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_rolling_window_algorithms);
+criterion_main!(benches);

--- a/packages/devkit/src/analysis/percentile.rs
+++ b/packages/devkit/src/analysis/percentile.rs
@@ -1,3 +1,15 @@
+/// Summary statistics for a fee distribution.
+#[derive(Debug, Clone)]
+pub struct FeeDistributionSummary {
+    pub min: u64,
+    pub max: u64,
+    pub mean: f64,
+    pub median: u64,
+    pub std_dev: f64,
+    /// Percentiles p10, p20, ..., p90, p99 (index 0 = p10, index 9 = p99).
+    pub percentiles: [u64; 10],
+}
+
 /// Computes percentile statistics over fee samples.
 pub struct Percentile;
 
@@ -26,6 +38,25 @@ impl Percentile {
         let hi = rank.ceil() as usize;
         let frac = rank - lo as f64;
         (sorted[lo] as f64 + frac * (sorted[hi] as f64 - sorted[lo] as f64)).round() as u64
+    }
+
+    /// Returns a full fee distribution summary for a sorted slice.
+    /// Returns `None` for empty slices.
+    pub fn fee_distribution_summary(sorted: &[u64]) -> Option<FeeDistributionSummary> {
+        if sorted.is_empty() {
+            return None;
+        }
+        let n = sorted.len();
+        let min = sorted[0];
+        let max = sorted[n - 1];
+        let mean = sorted.iter().map(|&x| x as f64).sum::<f64>() / n as f64;
+        let median = Self::nearest_rank(sorted, 50);
+        let variance =
+            sorted.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>() / n as f64;
+        let std_dev = variance.sqrt();
+        let ps = [10, 20, 30, 40, 50, 60, 70, 80, 90, 99];
+        let percentiles = ps.map(|p| Self::nearest_rank(sorted, p));
+        Some(FeeDistributionSummary { min, max, mean, median, std_dev, percentiles })
     }
 }
 
@@ -57,5 +88,21 @@ mod tests {
     #[test]
     fn linear_interpolation_empty() {
         assert_eq!(Percentile::linear_interpolation(&[], 50), 0);
+    }
+
+    #[test]
+    fn fee_distribution_summary_basic() {
+        let data = [10u64, 20, 30, 40, 50];
+        let s = Percentile::fee_distribution_summary(&data).unwrap();
+        assert_eq!(s.min, 10);
+        assert_eq!(s.max, 50);
+        assert_eq!(s.mean, 30.0);
+        assert_eq!(s.median, 30);
+        assert_eq!(s.percentiles[9], 50); // p99
+    }
+
+    #[test]
+    fn fee_distribution_summary_empty() {
+        assert!(Percentile::fee_distribution_summary(&[]).is_none());
     }
 }

--- a/packages/devkit/src/analysis/rolling_window.rs
+++ b/packages/devkit/src/analysis/rolling_window.rs
@@ -1,2 +1,54 @@
 /// Maintains a rolling window of fee observations.
 pub struct RollingWindow;
+
+impl RollingWindow {
+    /// Simple moving average over `window` elements.
+    pub fn sma(fees: &[u64], window: usize) -> Vec<f64> {
+        if window == 0 || fees.len() < window {
+            return vec![];
+        }
+        let mut sum: u64 = fees[..window].iter().sum();
+        let mut out = Vec::with_capacity(fees.len() - window + 1);
+        out.push(sum as f64 / window as f64);
+        for i in window..fees.len() {
+            sum += fees[i];
+            sum -= fees[i - window];
+            out.push(sum as f64 / window as f64);
+        }
+        out
+    }
+
+    /// Exponential moving average with smoothing factor `alpha` (0 < alpha <= 1).
+    pub fn ema(fees: &[u64], alpha: f64) -> Vec<f64> {
+        if fees.is_empty() {
+            return vec![];
+        }
+        let mut out = Vec::with_capacity(fees.len());
+        let mut prev = fees[0] as f64;
+        out.push(prev);
+        for &v in &fees[1..] {
+            prev = alpha * v as f64 + (1.0 - alpha) * prev;
+            out.push(prev);
+        }
+        out
+    }
+
+    /// Weighted moving average over `window` elements (linear weights).
+    pub fn wma(fees: &[u64], window: usize) -> Vec<f64> {
+        if window == 0 || fees.len() < window {
+            return vec![];
+        }
+        let denom = (window * (window + 1) / 2) as f64;
+        let mut out = Vec::with_capacity(fees.len() - window + 1);
+        for i in (window - 1)..fees.len() {
+            let val: f64 = fees[(i + 1 - window)..=i]
+                .iter()
+                .enumerate()
+                .map(|(j, &v)| (j + 1) as f64 * v as f64)
+                .sum::<f64>()
+                / denom;
+            out.push(val);
+        }
+        out
+    }
+}

--- a/packages/devkit/src/analysis/spike_classifier.rs
+++ b/packages/devkit/src/analysis/spike_classifier.rs
@@ -1,2 +1,49 @@
+use crate::analysis::percentile::Percentile;
+
 /// Classifies fee spikes in a time series.
 pub struct SpikeClassifier;
+
+impl SpikeClassifier {
+    /// Returns indices of fees that fall outside 1.5 × IQR from Q1/Q3.
+    /// `fees` need not be sorted; indices refer to the original slice.
+    pub fn iqr_outliers(fees: &[u64]) -> Vec<usize> {
+        if fees.len() < 4 {
+            return vec![];
+        }
+        let mut sorted = fees.to_vec();
+        sorted.sort_unstable();
+        let q1 = Percentile::nearest_rank(&sorted, 25) as f64;
+        let q3 = Percentile::nearest_rank(&sorted, 75) as f64;
+        let iqr = q3 - q1;
+        let lower = q1 - 1.5 * iqr;
+        let upper = q3 + 1.5 * iqr;
+        fees.iter()
+            .enumerate()
+            .filter(|(_, &v)| (v as f64) < lower || (v as f64) > upper)
+            .map(|(i, _)| i)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iqr_outliers_detects_spike() {
+        let fees = [100u64, 102, 98, 101, 99, 500, 103, 97];
+        let outliers = SpikeClassifier::iqr_outliers(&fees);
+        assert!(outliers.contains(&5), "500 should be flagged");
+    }
+
+    #[test]
+    fn iqr_outliers_no_outliers() {
+        let fees = [10u64, 11, 12, 13, 14, 15];
+        assert!(SpikeClassifier::iqr_outliers(&fees).is_empty());
+    }
+
+    #[test]
+    fn iqr_outliers_too_small() {
+        assert!(SpikeClassifier::iqr_outliers(&[1, 2, 3]).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Resolves four issues assigned to @temiport25 in the `devkit/analysis` package.

## Changes

### #151 — Fee distribution summary (`percentile.rs`)
- Added `FeeDistributionSummary` struct with `min`, `max`, `mean`, `median`, `std_dev`, and `percentiles` (p10–p99)
- Added `Percentile::fee_distribution_summary(sorted: &[u64]) -> Option<FeeDistributionSummary>`

### #152 — IQR outlier detection (`spike_classifier.rs`)
- Added `SpikeClassifier::iqr_outliers(fees: &[u64]) -> Vec<usize>`
- Flags indices of fees outside Q1 − 1.5×IQR or Q3 + 1.5×IQR

### #153 — Percentile benchmark (`benches/percentile_bench.rs`)
- Benchmarks `nearest_rank`, `linear_interpolation`, and `fee_distribution_summary` on 1,000,000 samples

### #154 — Rolling window benchmark (`benches/rolling_window_bench.rs`)
- Implemented `RollingWindow::sma`, `ema`, `wma` in `rolling_window.rs`
- Benchmarks all three algorithms on 100,000 samples

## Closes
Closes #151
Closes #152
Closes #153
Closes #154