### PR TITLE
fix(dashboard): stat cards, trend percentages, rolling windows + Render deploy

### DIFF
--- a/packages/core/src/config.rs
+++ b/packages/core/src/config.rs
@@ -102,7 +102,10 @@ impl Config {
             .ok_or("POLL_INTERVAL_SECONDS is required and must be a number")?;
 
         // -------- API Port --------
+        // API_PORT takes precedence; fall back to PORT (Render's injected var),
+        // then 8080 for local development.
         let api_port = get("API_PORT")
+            .or_else(|| get("PORT"))
             .and_then(|v| v.parse::<u16>().ok())
             .unwrap_or(8080);
 

--- a/packages/core/src/insights/config.rs
+++ b/packages/core/src/insights/config.rs
@@ -42,17 +42,17 @@ impl Default for InsightsConfig {
             time_windows: vec![
                 TimeWindow {
                     name: "short_term".to_string(),
-                    duration: Duration::hours(1),
-                    min_samples: 10,
+                    duration: Duration::minutes(5), // ~5 min window (matches UI label)
+                    min_samples: 5,
                 },
                 TimeWindow {
                     name: "medium_term".to_string(),
-                    duration: Duration::hours(6),
-                    min_samples: 30,
+                    duration: Duration::hours(1), // ~1 hour window (matches UI label)
+                    min_samples: 20,
                 },
                 TimeWindow {
                     name: "long_term".to_string(),
-                    duration: Duration::hours(24),
+                    duration: Duration::hours(24), // ~24 hour window (matches UI label)
                     min_samples: 100,
                 },
             ],

--- a/packages/core/src/insights/tests.rs
+++ b/packages/core/src/insights/tests.rs
@@ -915,6 +915,13 @@ mod tests {
                 transaction_hash: "hash4".to_string(),
                 ledger_sequence: 4,
             },
+            // Recent point within the 5-min short_term window
+            FeeDataPoint {
+                fee_amount: 110,
+                timestamp: now - Duration::minutes(2),
+                transaction_hash: "hash5".to_string(),
+                ledger_sequence: 5,
+            },
         ];
 
         // Process the fee data
@@ -924,10 +931,11 @@ mod tests {
         let update = result.unwrap();
 
         // Verify insights were calculated
+        // short_term window is 5 min — only hash5 qualifies; value should be 110
         assert!(update.insights.rolling_averages.short_term.value > 0.0);
         assert!(update.insights.extremes.current_min.value > 0);
         assert!(update.insights.extremes.current_max.value > 0);
-        assert_eq!(update.data_points_processed, 4);
+        assert_eq!(update.data_points_processed, 5);
     }
 
     #[test]

--- a/packages/core/src/services/horizon.rs
+++ b/packages/core/src/services/horizon.rs
@@ -39,8 +39,9 @@ pub struct HorizonFeeStats {
 pub struct FeeCharged {
     pub min: String,
     pub max: String,
-    /// The arithmetic mean fee charged across all transactions in the ledger.
-    /// Horizon exposes this as `"avg"` in the fee_stats response.
+    /// Horizon exposes the most-common fee as `"mode"` in fee_stats.
+    /// We surface it as `avg_fee` in the public API (typical fee charged).
+    #[serde(rename = "mode")]
     pub avg: String,
     pub p10: String,
     pub p20: String,
@@ -97,7 +98,7 @@ mod tests {
         let json = r#"{
             "min": "100",
             "max": "5000",
-            "avg": "213",
+            "mode": "213",
             "p10": "100",
             "p20": "100",
             "p30": "120",
@@ -134,7 +135,7 @@ mod tests {
             "fee_charged": {
                 "min": "100",
                 "max": "5000",
-                "avg": "213",
+                "mode": "213",
                 "p10": "100",
                 "p20": "100",
                 "p30": "120",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,74 @@
+## Render Blueprint — Stellar Fee Tracker
+## Deploy: `render blueprint apply` or connect the repo in the Render dashboard.
+## https://render.com/docs/blueprint-spec
+
+services:
+  # ── 1. Backend — Rust / Axum API ────────────────────────────────────────────
+  - type: web
+    name: stellar-fee-tracker-api
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    plan: free
+    healthCheckPath: /health
+    # Render injects PORT=10000; the binary falls back to PORT if API_PORT is unset.
+    envVars:
+      - key: STELLAR_NETWORK
+        value: testnet
+      - key: POLL_INTERVAL_SECONDS
+        value: "30"
+      - key: DATABASE_URL
+        value: sqlite:///data/stellar_fees.db
+      - key: RUST_LOG
+        value: info
+      - key: ALLOWED_ORIGINS
+        value: "*"
+    disk:
+      name: stellar-data
+      mountPath: /data
+      sizeGB: 1
+
+  # ── 2. Frontend — Next.js ───────────────────────────────────────────────────
+  - type: web
+    name: stellar-fee-tracker-ui
+    runtime: node
+    rootDir: packages/ui
+    buildCommand: npm ci && npm run build
+    startCommand: npm start
+    plan: free
+    envVars:
+      - key: NEXT_PUBLIC_API_URL
+        value: /api
+      - key: BACKEND_URL
+        # Next.js rewrites proxy /api/* → BACKEND_URL/*
+        fromService:
+          name: stellar-fee-tracker-api
+          type: web
+          property: url
+      - key: NEXT_PUBLIC_STELLAR_NETWORK
+        value: testnet
+      - key: NODE_ENV
+        value: production
+
+  # ── 3. Keep-alive cron — prevents free-tier cold starts ─────────────────────
+  # Free-tier web services sleep after 15 min of inactivity.
+  # This pings /health every 14 minutes to keep the backend warm.
+  - type: cron
+    name: stellar-keep-alive
+    schedule: "*/14 * * * *"
+    runtime: node
+    buildCommand: "true"
+    startCommand: >-
+      node -e "
+        const url = process.env.BACKEND_URL + '/health';
+        console.log('Pinging', url);
+        fetch(url)
+          .then(r => { console.log('Status:', r.status); if (!r.ok) process.exit(1); })
+          .catch(e => { console.error(e.message); process.exit(1); });
+      "
+    envVars:
+      - key: BACKEND_URL
+        fromService:
+          name: stellar-fee-tracker-api
+          type: web
+          property: url


### PR DESCRIPTION
Fixes three real-data issues discovered after #67 merged, plus Render Blueprint.

## Bugs Fixed

### 1. BASE FEE / AVG FEE always blank
FeeCharged was using `avg` as the serde field name, but Horizon fee_stats
returns "mode" — the whole /fees/current parse silently failed every time,
leaving both stat cards empty.
Fix: `#[serde(rename = "mode")]` on FeeCharged::avg.

### 2. Trend panel showing 0.0% always
InsightsConfig had windows of 1h/6h/24h, but the UI labels them 5min/1h/24h.
Because the windows were too wide, all three buffers held identical data on any
busy network, making all rolling averages equal and all trend deltas 0.0%.
Fix: Changed to minutes(5)/hours(1)/hours(24).

### 3. Integration test updated
Added a data point within the new 5-minute short-term window so the engine
integration test still passes.

## New: Render Blueprint

render.yaml deploys the full stack to Render.com:
- Backend: Docker (Rust/Axum); reads PORT env automatically via config fallback
- Frontend: Node/Next.js; BACKEND_URL linked via fromService
- Keep-alive cron: pings /health every 14 min to prevent free-tier cold starts

Generated with Claude Code
